### PR TITLE
fix(FAQPage): remove empty space between CTA button and footer

### DIFF
--- a/src/app/FAQPage/FAQpage.module.css
+++ b/src/app/FAQPage/FAQpage.module.css
@@ -1,12 +1,10 @@
 .page {
   display: flex;
   flex-direction: column;
-  min-height: 100vh; /* Garante que o layout ocupe toda a altura da viewport */
   background-color: #f6f6f6;
 }
 
 .content {
-  flex: 1;
   display: flex;
   flex-direction: column;
   gap: 1rem;


### PR DESCRIPTION
Remove min-height: 100vh from .page and flex: 1 from .content so the page sizes to its actual content. Previously, on short FAQ lists, the content area stretched to fill the viewport, leaving a visible gap between the "Entre em Contato" button and the footer's "Juntos somos mais fortes" image.