### PR TITLE
style(home): tweak typography and buttons to match design

### DIFF
--- a/src/app/home/components/campaignsCarousel.module.css
+++ b/src/app/home/components/campaignsCarousel.module.css
@@ -67,15 +67,15 @@
 }
 
 .cardTitle {
-  font-size: 10pt;
-  font-weight: 600;
+  font-size: 12px;
+  font-weight: 500;
   color: #363a1e;
   margin: 0;
   line-height: 1.3;
 }
 
 .cardDescription {
-  font-size: 9pt;
+  font-size: 10px;
   color: #263A1E;
   margin: 0;
   line-height: 1.4;

--- a/src/app/home/components/learnMoreButton.module.css
+++ b/src/app/home/components/learnMoreButton.module.css
@@ -4,8 +4,8 @@
   justify-content: center;
   color: #39542D;
   background-color: transparent;
-  border: 2px solid #39542D;
-  border-radius: 25px;
+  border: 1px solid #39542D;
+  border-radius: 10px;
   margin-top: 1.5rem;
   height: 50px;
   max-width: 100%;

--- a/src/app/home/homepage.module.css
+++ b/src/app/home/homepage.module.css
@@ -21,7 +21,7 @@
 
 .brigadasTitleWhite {
     font-weight: bold;
-    font-size: 14pt;
+    font-size: 18pt;
     margin-bottom: 2.5rem; 
     color: #ffffff;
     text-align: center;
@@ -36,7 +36,12 @@
 }
 
 .section {
-    padding: 1.5rem 1.5rem;
+    padding: 1.5rem;
+    color: #263A1E;
+}
+
+.campaignsSection {
+    padding: 1.5rem 1.5rem 0 1.5rem;
     color: #263A1E;
 }
 

--- a/src/app/home/page.js
+++ b/src/app/home/page.js
@@ -21,7 +21,7 @@ function Home() {
           <LatestNews/>
         </div>
       </section>
-      <section className={styles.section}>
+      <section className={styles.campaignsSection}>
         <div className={styles.brigadasTitle}>
           Descubra Nossas Campanhas
         </div>


### PR DESCRIPTION
- Carousel card title: 10pt/600 -> 12px/500; description: 9pt -> 10px.
- Learn-more button: border 2px -> 1px, radius 25px -> 10px.
- 'Brigadas' white title: 14pt -> 18pt.
- New .campaignsSection wrapper removes bottom padding on the campaigns section so it sits flush with the next block.