### PR TITLE
fix(admin): collapse sidebar into hamburger nav on mobile

### DIFF
--- a/src/app/admin/components/adminSidebar.js
+++ b/src/app/admin/components/adminSidebar.js
@@ -1,5 +1,6 @@
 "use client";
 
+import { useEffect, useRef, useState } from "react";
 import Link from "next/link";
 import { usePathname } from "next/navigation";
 import { useAuth0 } from "@auth0/auth0-react";
@@ -14,38 +15,95 @@ const LINKS = [
   { href: "/admin/usuarios", label: "Gerenciar usuários" },
 ];
 
-// Vertical navigation for the admin panel. Uses `startsWith` so /admin/brigadas
-// and /admin/brigadas/nova both highlight the same entry. The "Sair" button is
-// pinned to the bottom so it doesn't feel like just another destination.
+// Navigation for the admin panel.
+//
+// Desktop (>720px): a fixed vertical sidebar — the nav list is always visible
+// and the mobile toggle button is hidden via CSS.
+//
+// Mobile (<=720px): a compact top bar showing the brand + a hamburger button.
+// The nav list is collapsed by default and expands as a dropdown when toggled.
+// This keeps page content immediately visible instead of pushing it below a
+// full-height column. The disclosure is wired for accessibility: aria-expanded
+// /aria-controls on the button, Escape to close, outside-click to close, and
+// auto-close on route change so the panel never lingers over the new page.
 export default function AdminSidebar() {
   const pathname = usePathname() || "";
   const { logout } = useAuth0();
+  const [open, setOpen] = useState(false);
+  const navRef = useRef(null);
+
+  // Close the mobile dropdown whenever the route changes — tapping a link
+  // navigates, and we don't want the menu covering the destination page.
+  useEffect(() => {
+    setOpen(false);
+  }, [pathname]);
+
+  // While open, close on Escape or on a click/tap outside the nav.
+  useEffect(() => {
+    if (!open) return;
+    const onKeyDown = (event) => {
+      if (event.key === "Escape") setOpen(false);
+    };
+    const onPointerDown = (event) => {
+      if (navRef.current && !navRef.current.contains(event.target)) {
+        setOpen(false);
+      }
+    };
+    document.addEventListener("keydown", onKeyDown);
+    document.addEventListener("pointerdown", onPointerDown);
+    return () => {
+      document.removeEventListener("keydown", onKeyDown);
+      document.removeEventListener("pointerdown", onPointerDown);
+    };
+  }, [open]);
 
   return (
-    <nav className={styles.sidebar} aria-label="Navegação administrativa">
-      <div className={styles.brand}>Conexão Brigada · Admin</div>
-      {LINKS.map((link) => {
-        const isActive =
-          pathname === link.href || pathname.startsWith(`${link.href}/`);
-        return (
-          <Link
-            key={link.href}
-            href={link.href}
-            className={`${styles.link} ${isActive ? styles.active : ""}`}
-            aria-current={isActive ? "page" : undefined}
-          >
-            {link.label}
-          </Link>
-        );
-      })}
-      <div className={styles.logout}>
-        <Button
-          placeholder="Sair"
-          style="standard"
-          onPress={() =>
-            logout({ logoutParams: { returnTo: window.location.origin } })
-          }
-        />
+    <nav
+      ref={navRef}
+      className={styles.sidebar}
+      aria-label="Navegação administrativa"
+    >
+      <div className={styles.bar}>
+        <div className={styles.brand}>Conexão Brigada · Admin</div>
+        <button
+          type="button"
+          className={styles.toggle}
+          aria-expanded={open}
+          aria-controls="admin-nav-menu"
+          aria-label={open ? "Fechar menu" : "Abrir menu"}
+          onClick={() => setOpen((prev) => !prev)}
+        >
+          <span aria-hidden="true">{open ? "✕" : "☰"}</span>
+        </button>
+      </div>
+
+      <div
+        id="admin-nav-menu"
+        className={`${styles.menu} ${open ? styles.menuOpen : ""}`}
+      >
+        {LINKS.map((link) => {
+          const isActive =
+            pathname === link.href || pathname.startsWith(`${link.href}/`);
+          return (
+            <Link
+              key={link.href}
+              href={link.href}
+              className={`${styles.link} ${isActive ? styles.active : ""}`}
+              aria-current={isActive ? "page" : undefined}
+            >
+              {link.label}
+            </Link>
+          );
+        })}
+        <div className={styles.logout}>
+          <Button
+            placeholder="Sair"
+            style="standard"
+            onPress={() =>
+              logout({ logoutParams: { returnTo: window.location.origin } })
+            }
+          />
+        </div>
       </div>
     </nav>
   );

--- a/src/app/admin/components/adminSidebar.module.css
+++ b/src/app/admin/components/adminSidebar.module.css
@@ -8,6 +8,12 @@
   gap: 0.25rem;
 }
 
+.bar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+
 .brand {
   display: flex;
   align-items: center;
@@ -18,6 +24,21 @@
   font-size: 1rem;
   border-bottom: 1px solid #eee;
   margin-bottom: 0.75rem;
+}
+
+/* Hamburger toggle: only meaningful on mobile, hidden on desktop where the
+   full nav list is always visible. */
+.toggle {
+  display: none;
+}
+
+/* On desktop the menu is a plain vertical stack that grows to fill the
+   sidebar, pushing "Sair" to the bottom via the logout's margin-top: auto. */
+.menu {
+  display: flex;
+  flex-direction: column;
+  flex: 1;
+  gap: 0.25rem;
 }
 
 .link {
@@ -35,6 +56,11 @@
   background-color: var(--gray-200);
 }
 
+.link:focus-visible {
+  outline: 2px solid var(--green-600);
+  outline-offset: -2px;
+}
+
 .active {
   background-color: var(--green-200);
   color: var(--green-800);
@@ -44,5 +70,70 @@
 
 .logout {
   margin-top: auto;
-  padding: 0 1rem 1rem;
+  padding: 1rem 1rem 0;
+}
+
+.logout button:focus-visible {
+  outline: 2px solid var(--green-600);
+  outline-offset: 2px;
+}
+
+/* Mobile: the full-height vertical sidebar would fill the viewport and push
+   content below the fold, so we collapse it into a top bar with a hamburger.
+   The nav list is hidden until the toggle opens it as a dropdown. */
+@media (max-width: 720px) {
+  .sidebar {
+    min-height: 0;
+    padding: 0;
+    border-right: none;
+    border-bottom: 1px solid #e5e5e5;
+  }
+
+  .bar {
+    padding: 0.75rem 1rem;
+  }
+
+  .brand {
+    padding: 0;
+    margin-bottom: 0;
+    border-bottom: none;
+    font-size: 0.95rem;
+  }
+
+  .toggle {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 44px;
+    height: 44px;
+    border: 1px solid #e5e5e5;
+    border-radius: 8px;
+    background-color: var(--white);
+    color: var(--green-800);
+    font-size: 1.25rem;
+    line-height: 1;
+    cursor: pointer;
+  }
+
+  .toggle:focus-visible {
+    outline: 2px solid var(--green-600);
+    outline-offset: 2px;
+  }
+
+  /* Collapsed by default on mobile; .menuOpen reveals the dropdown. */
+  .menu {
+    display: none;
+    flex: none;
+    padding: 0.5rem 0 0.75rem;
+    border-top: 1px solid #eee;
+  }
+
+  .menuOpen {
+    display: flex;
+  }
+
+  .logout {
+    margin-top: 0.5rem;
+    padding: 0 1.25rem;
+  }
 }

--- a/src/app/admin/layout.module.css
+++ b/src/app/admin/layout.module.css
@@ -13,6 +13,10 @@
 @media (max-width: 720px) {
   .layout {
     grid-template-columns: 1fr;
+    /* Single column: the top bar takes its natural height and the content row
+       fills the rest. Without this, the grid stretches both auto rows to split
+       the 100vh evenly, ballooning the near-empty bar into a huge white block. */
+    grid-template-rows: auto 1fr;
   }
   .main {
     padding: 1rem;


### PR DESCRIPTION
## Summary

The admin panel was broken on mobile: a full-screen empty white block appeared above the page content, forcing users to scroll past a blank viewport to reach anything.

**Root cause:** the admin layout is a `grid` with `min-height: 100vh`. On mobile it collapsed to a single column, but (1) the sidebar kept `min-height: 100vh` with the logout button pinned via `margin-top: auto`, and (2) the grid stretched both auto rows to split the viewport evenly — so the near-empty sidebar row ballooned to half the screen.

**Fix:** on mobile the sidebar now becomes a compact top bar with a hamburger toggle that opens the nav as a dropdown. Desktop keeps the full vertical sidebar unchanged.

## Changes

- **`adminSidebar.js`** — split the nav into an always-visible `.bar` (brand + hamburger `.toggle`) and a collapsible `.menu`. On mobile the menu is a dropdown toggled by the button; on desktop it stays a full vertical list (toggle hidden via CSS). Disclosure wired for accessibility: `aria-expanded` / `aria-controls`, Escape to close, outside-click to close, and auto-close on route change.
- **`adminSidebar.module.css`** — mobile media query flattens the sidebar into a top bar, hides/reveals the menu, and adds a 44×44 touch-target toggle. Added `:focus-visible` outlines to links, the logout button, and the toggle (previously missing project-wide).
- **`layout.module.css`** — pin `grid-template-rows: auto 1fr` on mobile so the bar takes its natural height and content fills the rest.

## Test plan

- [x] Verified at 390px width: no empty white gap, content sits directly below the bar
- [x] Hamburger toggles the dropdown (all 5 links + Sair); `aria-expanded` and label flip correctly
- [x] Desktop layout unchanged (full vertical sidebar, toggle hidden)
- [x] Dev server compiles admin routes with no errors
- [ ] Manual keyboard pass (Tab/Escape/outside-click) on a real device

## Notes

- Accessibility reviewed: markup preserves the `nav` landmark, `aria-current`, and DOM/focus order; touch target is 44px; focus rings added.
- Unrelated: the "Internal Server Error" seen on admin list pages is a separate backend/Supabase connectivity issue, not addressed here.