### PR TITLE
feat(viewCampaignsPage): filter publications by type via tipo param

### DIFF
--- a/src/app/(public)/home/components/menuButton.js
+++ b/src/app/(public)/home/components/menuButton.js
@@ -10,8 +10,8 @@ const MENU_ITEMS = [
   { href: "/home", label: "Página Inicial", icon: Icons.globo },
   { href: "/viewBrigadesPage", label: "Visualizar Brigadas", icon: Icons.localizacao },
   { href: "/historiaPage", label: "História da RNBV", icon: Icons.livro },
-  { href: "/viewCampaignsPage", label: "Campanhas", icon: Icons.globo },
-  { href: "/artigosPage", label: "Artigos e Notícias", icon: Icons.jornal },
+  { href: "/viewCampaignsPage?tipo=campanhas", label: "Campanhas", icon: Icons.globo },
+  { href: "/viewCampaignsPage?tipo=artigos", label: "Artigos e Notícias", icon: Icons.jornal },
   { href: "/contactPage", label: "Entrar em contato", icon: Icons.mailverde },
   { href: "/FAQPage", label: "Dúvidas Frequentes", icon: Icons.ajudaverde },
 ];

--- a/src/app/(public)/home/page.js
+++ b/src/app/(public)/home/page.js
@@ -14,14 +14,14 @@ function Home() {
         </div>
         <div>
           <RedirectButton
-            link="/viewCampaignsPage"
+            link="/viewCampaignsPage?tipo=campanhas"
             label="Conheça Nossas Campanhas"
             variation="white"
           />
         </div>
         <div>
           <RedirectButton
-            link="/viewCampaignsPage"
+            link="/viewCampaignsPage?tipo=noticias"
             label="Acompanhe as Últimas Notícias"
             variation="white"
           />

--- a/src/app/(public)/viewCampaignsPage/page.js
+++ b/src/app/(public)/viewCampaignsPage/page.js
@@ -77,6 +77,11 @@ const VIEW_CONFIG = {
     sources: ["campaigns"],
   },
   noticias: {
+    title: "Notícias",
+    filterLabel: "Filtrar notícias",
+    sources: ["news"],
+  },
+  artigos: {
     title: "Artigos e Notícias",
     filterLabel: "Filtrar artigos e notícias",
     sources: ["news", "articles"],
@@ -89,7 +94,7 @@ const VIEW_CONFIG = {
 };
 
 const normalizeTipo = (raw) =>
-  raw === "campanhas" || raw === "noticias" ? raw : "all";
+  raw === "campanhas" || raw === "noticias" || raw === "artigos" ? raw : "all";
 
 const loadSources = async (sources, signal) => {
   const result = { campaigns: [], news: [], articles: [] };


### PR DESCRIPTION
- Conheça Nossas Campanhas -> ?tipo=campanhas (campaigns only)
- Acompanhe as Últimas Notícias -> ?tipo=noticias (news only)
- menu Artigos e Notícias -> ?tipo=artigos (news + articles)

Split the noticias view into news-only and add an artigos view for news + articles, and extend normalizeTipo to accept the new key.