### PR TITLE
feat(contactPage): custom select dropdown com busca e brigadas do banco

### DIFF
--- a/src/app/(public)/contactPage/components/customSelect.js
+++ b/src/app/(public)/contactPage/components/customSelect.js
@@ -1,0 +1,251 @@
+"use client";
+
+import { useEffect, useId, useRef, useState } from "react";
+import Label from "../../../components/label";
+import styles from "./customSelect.module.css";
+
+// Dropdown customizado fiel ao mock da página de Contato:
+// - chevron que inverte ao abrir/fechar
+// - painel de opções arredondado com sombra
+// - checkmark verde na opção selecionada
+//
+// Mantém compatibilidade com o form existente (que lê valores via
+// document.getElementsByName(name)[0].value) através de um <input type="hidden">.
+export default function CustomSelect({
+  label,
+  placeholder,
+  items = [],
+  name,
+  width,
+  value,
+  onChange,
+  disabled = false,
+  searchable = false,
+  searchPlaceholder = "Buscar...",
+  loading = false,
+}) {
+  const reactId = useId();
+  const selectId = name ? `select-${name}` : `select-${reactId}`;
+  const listId = `${selectId}-list`;
+
+  const isControlled = value !== undefined;
+  const [internalKey, setInternalKey] = useState("");
+  const selectedKey = isControlled ? value : internalKey;
+  const [open, setOpen] = useState(false);
+  const [activeIndex, setActiveIndex] = useState(-1);
+  const [query, setQuery] = useState("");
+  const rootRef = useRef(null);
+  const buttonRef = useRef(null);
+  const searchRef = useRef(null);
+
+  const selectedItem = items.find((item) => item.key === selectedKey);
+  const displayText = selectedItem ? selectedItem.value : placeholder;
+
+  // Lista filtrada pelo texto digitado (só quando searchable).
+  const visibleItems =
+    searchable && query.trim()
+      ? items.filter((item) =>
+          item.value.toLowerCase().includes(query.trim().toLowerCase()),
+        )
+      : items;
+
+  // Fecha ao clicar fora.
+  useEffect(() => {
+    if (!open) return;
+    const onClickOutside = (event) => {
+      if (rootRef.current && !rootRef.current.contains(event.target)) {
+        setOpen(false);
+      }
+    };
+    document.addEventListener("mousedown", onClickOutside);
+    return () => document.removeEventListener("mousedown", onClickOutside);
+  }, [open]);
+
+  // Ao abrir com busca, foca o campo e zera o filtro anterior.
+  useEffect(() => {
+    if (open && searchable) {
+      setQuery("");
+      // foca no próximo tick, após o painel montar
+      const id = setTimeout(() => searchRef.current?.focus(), 0);
+      return () => clearTimeout(id);
+    }
+  }, [open, searchable]);
+
+  // Mantém o item ativo dentro dos limites da lista filtrada.
+  useEffect(() => {
+    if (!open) return;
+    setActiveIndex((i) => Math.min(i, Math.max(0, visibleItems.length - 1)));
+  }, [visibleItems.length, open]);
+
+  const select = (key) => {
+    if (!isControlled) setInternalKey(key);
+    onChange?.(key);
+    setOpen(false);
+    buttonRef.current?.focus();
+  };
+
+  const toggle = () => {
+    if (disabled) return;
+    setOpen((prev) => {
+      const next = !prev;
+      if (next) {
+        const idx = items.findIndex((i) => i.key === selectedKey);
+        setActiveIndex(idx >= 0 ? idx : 0);
+      }
+      return next;
+    });
+  };
+
+  const onKeyDown = (event) => {
+    if (disabled) return;
+    switch (event.key) {
+      case "ArrowDown":
+        event.preventDefault();
+        if (!open) {
+          setOpen(true);
+          setActiveIndex(Math.max(0, items.findIndex((i) => i.key === selectedKey)));
+        } else {
+          setActiveIndex((i) => Math.min(visibleItems.length - 1, i + 1));
+        }
+        break;
+      case "ArrowUp":
+        event.preventDefault();
+        if (open) setActiveIndex((i) => Math.max(0, i - 1));
+        break;
+      case "Enter":
+        event.preventDefault();
+        if (open && activeIndex >= 0 && visibleItems[activeIndex]) {
+          select(visibleItems[activeIndex].key);
+        } else {
+          toggle();
+        }
+        break;
+      case " ":
+        // No modo busca, espaço é digitação normal no input; não alterna.
+        if (searchable && open) break;
+        event.preventDefault();
+        if (open && activeIndex >= 0 && visibleItems[activeIndex]) {
+          select(visibleItems[activeIndex].key);
+        } else {
+          toggle();
+        }
+        break;
+      case "Escape":
+        setOpen(false);
+        break;
+      default:
+        break;
+    }
+  };
+
+  return (
+    <div style={{ width }}>
+      {label && (
+        <div className={styles.labelpadding}>
+          <Label text={label} htmlFor={selectId} />
+        </div>
+      )}
+      <div className={styles.root} ref={rootRef}>
+        <button
+          type="button"
+          id={selectId}
+          ref={buttonRef}
+          className={`${styles.control} ${open ? styles.controlOpen : ""} ${
+            disabled ? styles.disabled : ""
+          }`}
+          onClick={toggle}
+          onKeyDown={onKeyDown}
+          disabled={disabled}
+          aria-haspopup="listbox"
+          aria-expanded={open}
+          aria-controls={listId}
+        >
+          <span className={selectedItem ? styles.valueText : styles.placeholderText}>
+            {displayText}
+          </span>
+          <svg
+            className={`${styles.chevron} ${open ? styles.chevronOpen : ""}`}
+            width="20"
+            height="20"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="2"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            aria-hidden="true"
+          >
+            <polyline points="6 9 12 15 18 9" />
+          </svg>
+        </button>
+
+        {open && (
+          <div className={styles.panel}>
+            {searchable && (
+              <div className={styles.searchWrap}>
+                <input
+                  ref={searchRef}
+                  type="text"
+                  className={styles.searchInput}
+                  placeholder={searchPlaceholder}
+                  value={query}
+                  onChange={(e) => {
+                    setQuery(e.target.value);
+                    setActiveIndex(0);
+                  }}
+                  onKeyDown={onKeyDown}
+                  aria-label={searchPlaceholder}
+                />
+              </div>
+            )}
+            <ul className={styles.list} id={listId} role="listbox" aria-labelledby={selectId}>
+              {loading ? (
+                <li className={styles.empty}>Carregando...</li>
+              ) : visibleItems.length === 0 ? (
+                <li className={styles.empty}>Nenhum resultado</li>
+              ) : (
+                visibleItems.map((item, index) => {
+                  const isSelected = item.key === selectedKey;
+                  const isActive = index === activeIndex;
+                  return (
+                    <li
+                      key={item.key}
+                      role="option"
+                      aria-selected={isSelected}
+                      className={`${styles.option} ${isActive ? styles.optionActive : ""} ${
+                        isSelected ? styles.optionSelected : ""
+                      }`}
+                      onMouseEnter={() => setActiveIndex(index)}
+                      onClick={() => select(item.key)}
+                    >
+                      <span>{item.value}</span>
+                      {isSelected && (
+                        <svg
+                          className={styles.check}
+                          width="20"
+                          height="20"
+                          viewBox="0 0 24 24"
+                          fill="none"
+                          stroke="#84C868"
+                          strokeWidth="2.5"
+                          strokeLinecap="round"
+                          strokeLinejoin="round"
+                          aria-hidden="true"
+                        >
+                          <polyline points="20 6 9 17 4 12" />
+                        </svg>
+                      )}
+                    </li>
+                  );
+                })
+              )}
+            </ul>
+          </div>
+        )}
+      </div>
+
+      {/* Mantém o form existente funcionando (leitura por getElementsByName). */}
+      <input type="hidden" name={name} value={selectedKey} readOnly />
+    </div>
+  );
+}

--- a/src/app/(public)/contactPage/components/customSelect.module.css
+++ b/src/app/(public)/contactPage/components/customSelect.module.css
@@ -1,0 +1,144 @@
+.root {
+  position: relative;
+  width: 100%;
+}
+
+.labelpadding {
+  margin-bottom: 0.25rem;
+}
+
+/* Controle (campo fechado) — mesmo visual dos inputs da página. */
+.control {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  width: 100%;
+  gap: 0.5rem;
+  border-radius: 0.75rem;
+  border: 0.1rem solid #B3B3B3;
+  padding: 0.9rem 1rem;
+  font-size: 1rem;
+  font-family: "Montserrat", sans-serif;
+  background-color: #FFFFFF;
+  color: #263A1E;
+  cursor: pointer;
+  text-align: left;
+}
+
+/* Aberto ou focado: borda verde da marca, como no mock. */
+.control:focus-visible,
+.controlOpen {
+  border-color: #84C868;
+  outline: none;
+  box-shadow: 0 0 0 1px #84C868;
+}
+
+.disabled {
+  cursor: not-allowed;
+  background-color: #F5F5F5;
+  color: #9A9A9A;
+}
+
+.valueText {
+  color: #263A1E;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.placeholderText {
+  color: #757575;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.chevron {
+  color: #757575;
+  flex-shrink: 0;
+  transition: transform 0.2s ease;
+}
+
+/* Chevron aponta para cima quando aberto, fiel ao mock. */
+.chevronOpen {
+  transform: rotate(180deg);
+}
+
+/* Painel de opções — arredondado, com sombra, sobreposto. */
+.panel {
+  position: absolute;
+  top: calc(100% + 0.4rem);
+  left: 0;
+  z-index: 20;
+  width: 100%;
+  background-color: #FFFFFF;
+  border-radius: 0.75rem;
+  box-shadow: 0 6px 20px rgba(0, 0, 0, 0.18);
+  overflow: hidden;
+}
+
+/* Campo de busca no topo do painel (modo searchable). */
+.searchWrap {
+  padding: 0.5rem;
+  border-bottom: 0.05rem solid #EAEAEA;
+}
+
+.searchInput {
+  width: 100%;
+  box-sizing: border-box;
+  border-radius: 0.5rem;
+  border: 0.1rem solid #B3B3B3;
+  padding: 0.6rem 0.8rem;
+  font-size: 0.95rem;
+  font-family: "Montserrat", sans-serif;
+  color: #263A1E;
+  outline: none;
+}
+
+.searchInput:focus {
+  border-color: #84C868;
+  box-shadow: 0 0 0 1px #84C868;
+}
+
+.list {
+  max-height: 15rem;
+  overflow-y: auto;
+  margin: 0;
+  padding: 0.25rem 0;
+  list-style: none;
+}
+
+/* Estado vazio / carregando dentro do painel. */
+.empty {
+  padding: 0.85rem 1rem;
+  font-size: 0.95rem;
+  font-family: "Montserrat", sans-serif;
+  color: #757575;
+  text-align: center;
+}
+
+.option {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.5rem;
+  padding: 0.85rem 1rem;
+  font-size: 1rem;
+  font-family: "Montserrat", sans-serif;
+  color: #263A1E;
+  cursor: pointer;
+}
+
+/* Item sob o cursor / navegação por teclado. */
+.optionActive {
+  background-color: #F2F2F2;
+}
+
+/* Item selecionado — leve destaque, com checkmark verde. */
+.optionSelected {
+  background-color: #F7F7F7;
+}
+
+.check {
+  flex-shrink: 0;
+}

--- a/src/app/(public)/contactPage/css.css
+++ b/src/app/(public)/contactPage/css.css
@@ -1,3 +1,87 @@
-.form > * {
-  margin-bottom: 0.5rem;
+/* Espaçamento vertical generoso entre os campos, fiel ao mock. */
+.form {
+  display: flex;
+  flex-direction: column;
 }
+
+.form > * {
+  margin-bottom: 1.5rem;
+}
+
+/* Mensagens de erro devem colar no campo acima, sem herdar o respiro grande. */
+.form > span {
+  margin-top: -1.25rem;
+  margin-bottom: 1rem;
+}
+
+/* Inputs e selects mais altos e arredondados, como no mock. Escopado à
+   página de contato para não alterar os formulários do admin. */
+.form input,
+.form select {
+  border-radius: 0.75rem;
+  border: 0.1rem solid #B3B3B3;
+  padding: 0.9rem 1rem;
+  font-size: 1rem;
+}
+
+/* Chevron custom fino no lugar da seta nativa do select, fiel ao mock. */
+.form select {
+  appearance: none;
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  padding-right: 2.75rem;
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='20' height='20' viewBox='0 0 24 24' fill='none' stroke='%23757575' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpolyline points='6 9 12 15 18 9'/%3E%3C/svg%3E");
+  background-repeat: no-repeat;
+  background-position: right 1rem center;
+  background-size: 1.25rem;
+}
+
+/* Estado de foco (ao clicar no campo): borda verde da marca. */
+.form input:focus,
+.form select:focus {
+  border-color: #39542D;
+  outline: none;
+  box-shadow: 0 0 0 1px #39542D;
+}
+
+
+/* Checkbox de Termos como círculo custom, fiel ao mock. */
+.termsCheckbox {
+  appearance: none;
+  -webkit-appearance: none;
+  width: 1.5rem;
+  height: 1.5rem;
+  min-width: 1.5rem;
+  margin-right: 0.75rem;
+  border: 0.1rem solid #B3B3B3;
+  border-radius: 50%;
+  background-color: #FFFFFF;
+  cursor: pointer;
+  display: inline-grid;
+  place-content: center;
+  transition: border-color 0.2s, background-color 0.2s;
+}
+
+.termsCheckbox::before {
+  content: "";
+  width: 0.75rem;
+  height: 0.75rem;
+  border-radius: 50%;
+  transform: scale(0);
+  transition: transform 0.15s ease-in-out;
+  background-color: #39542D;
+}
+
+.termsCheckbox:checked {
+  border-color: #39542D;
+}
+
+.termsCheckbox:checked::before {
+  transform: scale(1);
+}
+
+.termsCheckbox:focus-visible {
+  outline: 2px solid #84C868;
+  outline-offset: 2px;
+}
+

--- a/src/app/(public)/contactPage/page.js
+++ b/src/app/(public)/contactPage/page.js
@@ -1,9 +1,9 @@
 'use client';
 
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import Button, { ButtonStyle } from "../../components/button";
 import Input from "../../components/input";
-import Select from "../../components/select";
+import CustomSelect from "./components/customSelect";
 import StateCodes from "../../constants/estados";
 import ContactReasons from "../../constants/contactReasons";
 import "./css.css";
@@ -12,12 +12,61 @@ import { useRouter } from "next/navigation";
 import SaveModal from "../../components/saveModal";
 import EmailValidator from "../../validators/emailValidator";
 import PhoneValidator from "../../validators/phoneValidator";
+import { api } from "@/lib/api";
+
+// A RNBV é a própria organização da plataforma (não é uma brigada do banco).
+// Fica sempre como primeira opção e é o default do campo.
+const RNBV_OPTION = { key: "rnbv", value: "RNBV - Rede Nacional de Brigadas Voluntárias" };
 
 function Contact() {
-  const [state, setState] = useState(StateCodes[0].key);
+  const [state, setState] = useState("");
+  const [city, setCity] = useState("");
+  const [contactReason, setContactReason] = useState("");
+  const [brigade, setBrigade] = useState(RNBV_OPTION.key);
+  const [brigadeItems, setBrigadeItems] = useState([RNBV_OPTION]);
+  const [brigadesLoading, setBrigadesLoading] = useState(true);
   const [isSaveSuccess, setIsSaveSuccess] = useState(false);
   const [errors, setErrors] = useState({});
   const router = useRouter();
+
+  const onStateChange = (key) => {
+    setState(key);
+    setCity(""); // reseta a cidade ao trocar de estado
+  };
+
+  // Remove o erro de um campo assim que o usuário começa a corrigi-lo.
+  // A revalidação completa continua acontecendo no submit.
+  const clearError = (field) => {
+    setErrors((prev) => {
+      if (!prev[field]) return prev;
+      const next = { ...prev };
+      delete next[field];
+      return next;
+    });
+  };
+
+  // Carrega as brigadas reais do banco e monta a lista com a RNBV fixa no topo.
+  useEffect(() => {
+    const ctrl = new AbortController();
+    const load = async () => {
+      try {
+        setBrigadesLoading(true);
+        const res = await api.brigades.list({ limit: 100 }, { signal: ctrl.signal });
+        const fromDb = (res?.data ?? []).map((b) => ({ key: b.id, value: b.name }));
+        setBrigadeItems([RNBV_OPTION, ...fromDb]);
+      } catch (err) {
+        if (err.name === "AbortError") return;
+        // eslint-disable-next-line no-console
+        console.error("[Contact] falha ao carregar brigadas", err);
+        // Mantém ao menos a RNBV disponível se o fetch falhar.
+        setBrigadeItems([RNBV_OPTION]);
+      } finally {
+        setBrigadesLoading(false);
+      }
+    };
+    load();
+    return () => ctrl.abort();
+  }, []);
 
   const validate = () => {
     const newErrors = {};
@@ -46,6 +95,11 @@ function Contact() {
     const message = getValue("message");
     if (!message.trim()) {
       newErrors.message = "Campo obrigatório";
+    }
+
+    const selectedBrigade = getValue("brigade");
+    if (!selectedBrigade.trim()) {
+      newErrors.brigade = "Selecione uma brigada";
     }
 
     const acceptedTerms = document.getElementsByName("terms")[0]?.checked;
@@ -96,31 +150,32 @@ function Contact() {
             id="contactForm"
             className="form"
           >
-            <Input label="Nome e Sobrenome" placeholder="Seu nome" name="name"/>
+            <Input label="Nome" placeholder="Seu nome" name="name" onChange={() => clearError("name")}/>
             {errors.name && <span style={{font: "normal normal normal 12px/15px Montserrat", color: "#D92D20"}}>{errors.name}</span>}
 
-            <Input label="E-mail de Contato" placeholder="Seu e-mail" type="email" name="email"/>
+            <Input label="E-mail de Contato" placeholder="Seu e-mail" type="email" name="email" onChange={() => clearError("email")}/>
             {errors.email && <span style={{font: "normal normal normal 12px/15px Montserrat", color: "#D92D20"}}>{errors.email}</span>}
 
-            <Input label="Telefone de Contato" placeholder="Seu telefone" type="phone" name="phone"/>
+            <Input label="Telefone de Contato" placeholder="Seu telefone" type="phone" name="phone" onChange={() => clearError("phone")}/>
             {errors.phone && <span style={{font: "normal normal normal 12px/15px Montserrat", color: "#D92D20"}}>{errors.phone}</span>}
 
             <div style={{display: "flex", width: "100%"}}>
-              <Select label="Estado" items={StateCodes} placeholder="UF" setSelectedKey={setState} name="state"/>
+              <CustomSelect label="Estado" items={StateCodes} placeholder="UF" value={state} onChange={onStateChange} name="state" width="30%"/>
               <span style={{marginLeft: "1rem"}}/>
-              <Select label="Cidade" items={CitiesByState[state] || []} placeholder="Selecione a sua cidade" width="100%" name="city"/>
+              <CustomSelect label="Cidade" items={CitiesByState[state] || []} placeholder="Selecione a sua cidade" value={city} onChange={setCity} width="100%" name="city"/>
             </div>
 
-            <Select label="Motivo do Contato" placeholder="Selecione o motivo do contato" width="100%" items={ContactReasons} name="contactReason"/>
+            <CustomSelect label="Motivo do Contato" placeholder="Selecione o motivo do contato" width="100%" items={ContactReasons} value={contactReason} onChange={setContactReason} name="contactReason"/>
 
-            <Select label="Deseja falar com uma brigada específica? Se sim, selecione a brigada desejada." placeholder="Selecione uma brigada" width="100%" name="brigade" />
+            <CustomSelect label="Deseja falar com uma organização específica? Se sim, selecione abaixo:" placeholder="Selecione uma brigada" width="100%" items={brigadeItems} value={brigade} onChange={(key) => { setBrigade(key); clearError("brigade"); }} name="brigade" searchable searchPlaceholder="Buscar brigada..." loading={brigadesLoading} />
+            {errors.brigade && <span style={{font: "normal normal normal 12px/15px Montserrat", color: "#D92D20"}}>{errors.brigade}</span>}
 
-            <Input label="Mensagem" placeholder="Digite aqui a sua mensagem" height="5rem" name="message"/>
+            <Input label="Mensagem" placeholder="Digite aqui a sua mensagem" height="5rem" name="message" onChange={() => clearError("message")}/>
             {errors.message && <span style={{font: "normal normal normal 12px/15px Montserrat", color: "#D92D20"}}>{errors.message}</span>}
           </form>
 
           <div style={{display: "flex", alignItems: "center", marginTop: "2rem"}}>
-            <input style={{marginRight: "0.5rem", border: "1px solid #39542D"}} type="checkbox" id="terms" name="terms" value="accepted"/>
+            <input className="termsCheckbox" type="checkbox" id="terms" name="terms" value="accepted" onChange={() => clearError("terms")}/>
             <label htmlFor="terms" style={{color: "#39542D", font: "normal normal normal 16px/20px 'Montserrat'", fontFamily: "'Montserrat', sans-serif" }}>Afirmo que li e aceito os Termos e Condições</label>
           </div>
           {errors.terms && <span style={{font: "normal normal normal 12px/15px Montserrat", color: "#D92D20"}}>{errors.terms}</span>}

--- a/src/app/(public)/layout 2.js
+++ b/src/app/(public)/layout 2.js
@@ -1,0 +1,16 @@
+import Header from "../components/header";
+import Footer from "../components/footer";
+
+// Layout for the public site. The (public) segment is a route group — it does
+// NOT appear in the URL — so /home, /viewBrigadesPage, /FAQPage, etc. keep
+// their existing paths, but inherit this header/footer chrome. Admin pages
+// (src/app/admin/*) sit outside this group and render their own shell.
+export default function PublicLayout({ children }) {
+  return (
+    <>
+      <Header />
+      {children}
+      <Footer />
+    </>
+  );
+}

--- a/src/app/(public)/page 2.js
+++ b/src/app/(public)/page 2.js
@@ -1,0 +1,10 @@
+import Home from "./home/page";
+
+function Page() {
+
+  return (
+    <Home />
+  );
+}
+
+export default Page

--- a/src/app/(public)/page.module 2.css
+++ b/src/app/(public)/page.module 2.css
@@ -1,0 +1,165 @@
+.page {
+  --gray-rgb: 0, 0, 0;
+  --gray-alpha-200: rgba(var(--gray-rgb), 0.08);
+  --gray-alpha-100: rgba(var(--gray-rgb), 0.05);
+
+  --button-primary-hover: #383838;
+  --button-secondary-hover: #f2f2f2;
+
+  display: grid;
+  grid-template-rows: 20px 1fr 20px;
+  align-items: center;
+  justify-items: center;
+  min-height: 100svh;
+  padding: 80px;
+  gap: 64px;
+  font-family: var(--font-geist-sans);
+}
+
+@media (prefers-color-scheme: dark) {
+  .page {
+    --gray-rgb: 255, 255, 255;
+    --gray-alpha-200: rgba(var(--gray-rgb), 0.145);
+    --gray-alpha-100: rgba(var(--gray-rgb), 0.06);
+
+    --button-primary-hover: #ccc;
+    --button-secondary-hover: #1a1a1a;
+  }
+}
+
+.main {
+  display: flex;
+  flex-direction: column;
+  gap: 32px;
+  grid-row-start: 2;
+}
+
+.main ol {
+  font-family: var(--font-geist-mono);
+  padding-left: 0;
+  margin: 0;
+  font-size: 14px;
+  line-height: 24px;
+  letter-spacing: -0.01em;
+  list-style-position: inside;
+}
+
+.main li:not(:last-of-type) {
+  margin-bottom: 8px;
+}
+
+.main code {
+  font-family: inherit;
+  background: var(--gray-alpha-100);
+  padding: 2px 4px;
+  border-radius: 4px;
+  font-weight: 600;
+}
+
+.ctas {
+  display: flex;
+  gap: 16px;
+}
+
+.ctas a {
+  appearance: none;
+  border-radius: 128px;
+  height: 48px;
+  padding: 0 20px;
+  border: none;
+  border: 1px solid transparent;
+  transition: background 0.2s, color 0.2s, border-color 0.2s;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 16px;
+  line-height: 20px;
+  font-weight: 500;
+}
+
+a.primary {
+  background: var(--foreground);
+  color: var(--background);
+  gap: 8px;
+}
+
+a.secondary {
+  border-color: var(--gray-alpha-200);
+  min-width: 180px;
+}
+
+.footer {
+  grid-row-start: 3;
+  display: flex;
+  gap: 24px;
+}
+
+.footer a {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.footer img {
+  flex-shrink: 0;
+}
+
+/* Enable hover only on non-touch devices */
+@media (hover: hover) and (pointer: fine) {
+  a.primary:hover {
+    background: var(--button-primary-hover);
+    border-color: transparent;
+  }
+
+  a.secondary:hover {
+    background: var(--button-secondary-hover);
+    border-color: transparent;
+  }
+
+  .footer a:hover {
+    text-decoration: underline;
+    text-underline-offset: 4px;
+  }
+}
+
+@media (max-width: 600px) {
+  .page {
+    padding: 32px;
+    padding-bottom: 80px;
+  }
+
+  .main {
+    align-items: center;
+  }
+
+  .main ol {
+    text-align: center;
+  }
+
+  .ctas {
+    flex-direction: column;
+  }
+
+  .ctas a {
+    font-size: 14px;
+    height: 40px;
+    padding: 0 16px;
+  }
+
+  a.secondary {
+    min-width: auto;
+  }
+
+  .footer {
+    flex-wrap: wrap;
+    align-items: center;
+    justify-content: center;
+  }
+}
+
+@media (prefers-color-scheme: dark) {
+  .logo {
+    filter: invert();
+  }
+}

--- a/src/app/admin/layout 2.js
+++ b/src/app/admin/layout 2.js
@@ -1,0 +1,53 @@
+"use client";
+
+import { useEffect } from "react";
+import { useAuth0 } from "@auth0/auth0-react";
+import { usePathname } from "next/navigation";
+import RequireAdmin from "./components/requireAdmin";
+import AdminSidebar from "./components/adminSidebar";
+import { setTokenProvider, clearTokenProvider } from "@/lib/apiAuth";
+import { getConfig } from "../config";
+import styles from "./layout.module.css";
+
+// Layout shared by every /admin/* route. Renders the two-pane shell (sidebar
+// + main) and connects the Auth0 token retrieval to the shared API client so
+// writes attach an access token automatically.
+//
+// The /admin/login page bypasses the RequireAdmin gate and the sidebar
+// chrome — a user landing there hasn't authenticated yet.
+export default function AdminLayout({ children }) {
+  const pathname = usePathname() || "";
+  const isLoginRoute = pathname === "/admin/login";
+
+  return isLoginRoute ? (
+    <>{children}</>
+  ) : (
+    <RequireAdmin>
+      <TokenBridge />
+      <div className={styles.layout}>
+        <AdminSidebar />
+        <main className={styles.main}>{children}</main>
+      </div>
+    </RequireAdmin>
+  );
+}
+
+// Small effect-only component that registers the Auth0 token provider on
+// mount and clears it on unmount. Kept separate so it can sit *inside*
+// RequireAdmin and only run after the user is authenticated (and thus
+// getAccessTokenSilently will actually work).
+function TokenBridge() {
+  const { getAccessTokenSilently } = useAuth0();
+  useEffect(() => {
+    const { audience } = getConfig();
+    setTokenProvider(() =>
+      getAccessTokenSilently(
+        audience
+          ? { authorizationParams: { audience } }
+          : undefined
+      )
+    );
+    return () => clearTokenProvider();
+  }, [getAccessTokenSilently]);
+  return null;
+}

--- a/src/app/admin/layout.module 2.css
+++ b/src/app/admin/layout.module 2.css
@@ -1,0 +1,24 @@
+.layout {
+  display: grid;
+  grid-template-columns: 240px 1fr;
+  min-height: 100vh;
+  background-color: var(--gray-200);
+}
+
+.main {
+  padding: 1.5rem 2rem;
+  min-width: 0;
+}
+
+@media (max-width: 720px) {
+  .layout {
+    grid-template-columns: 1fr;
+    /* Single column: the top bar takes its natural height and the content row
+       fills the rest. Without this, the grid stretches both auto rows to split
+       the 100vh evenly, ballooning the near-empty bar into a huge white block. */
+    grid-template-rows: auto 1fr;
+  }
+  .main {
+    padding: 1rem;
+  }
+}

--- a/src/app/admin/page 2.js
+++ b/src/app/admin/page 2.js
@@ -1,0 +1,7 @@
+import { redirect } from "next/navigation";
+
+// Landing on /admin sends you straight to the change-password screen, which
+// mirrors the wireframe's default active-tab.
+export default function AdminIndex() {
+  redirect("/admin/redefinir-senha");
+}

--- a/src/app/components/campaignList 2.js
+++ b/src/app/components/campaignList 2.js
@@ -1,0 +1,37 @@
+import { NavigationCard } from "@/app/components/navigationCard";
+import Skeleton from "@/app/components/skeleton";
+
+const PLACEHOLDER_IMAGE = "/placeholder-brigade.svg";
+const SKELETON_COUNT = 3;
+
+export default function CampaignList({ loading, error, campaigns }) {
+    if (loading) {
+        return (
+            <div className="align-center flex flex-col gap-3 py-5">
+                {Array.from({ length: SKELETON_COUNT }).map((_, i) => (
+                    <Skeleton
+                        key={i}
+                        width={360}
+                        height={150}
+                        radius={8}
+                        ariaLabel="Carregando campanha"
+                    />
+                ))}
+            </div>
+        );
+    }
+    if (error) return <p className="py-5" style={{ color: "#C62828" }}>{error}</p>;
+    if (!campaigns.length) return <p className="py-5">Nenhuma campanha disponível no momento.</p>;
+
+    return (
+        <div className="align-center flex flex-col gap-3 py-5">
+            {campaigns.map((c) => (
+                <NavigationCard
+                    key={c.id}
+                    title={c.title}
+                    backgroundImage={c.imageUrl || PLACEHOLDER_IMAGE}
+                />
+            ))}
+        </div>
+    );
+}

--- a/src/app/components/navigationCard 2.js
+++ b/src/app/components/navigationCard 2.js
@@ -1,0 +1,43 @@
+import React from 'react';
+import styles from './navigationCard.module.css';
+
+export const NavigationCard = ({ 
+  title = "Cinzas da Floresta", 
+  backgroundImage,
+  onArrowClick 
+}) => {
+  return (
+    <div className={`${styles['navigation-card']} position-relative rounded`}>
+      <div 
+        className={styles['navigation-card__background']}
+        style={{ backgroundImage: `url(${backgroundImage})` }}
+      >
+        <div className={styles['navigation-card__overlay']} />
+      </div>
+      
+      <div className={styles['navigation-card__content']}>
+        <h2 className={styles['navigation-card__title']}>{title}</h2>
+      </div>
+
+      <button 
+        className={`${styles['navigation-card__arrow']} flex align-center justify-center`} 
+        onClick={onArrowClick}
+        aria-label="View more"
+      >
+        <svg 
+          width="24" 
+          height="24" 
+          viewBox="0 0 24 24" 
+          fill="none" 
+          stroke="currentColor" 
+          strokeWidth="2"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+        >
+          <line x1="5" y1="12" x2="19" y2="12" />
+          <polyline points="12 5 19 12 12 19" />
+        </svg>
+      </button>
+    </div>
+  );
+};

--- a/src/app/components/navigationCard.module 2.css
+++ b/src/app/components/navigationCard.module 2.css
@@ -1,0 +1,67 @@
+.navigation-card {
+  width: 100%;
+  height: 150px;
+  overflow: hidden;
+  cursor: pointer;
+  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+}
+
+.navigation-card__background {
+  position: absolute;
+  inset: 0;
+  background-size: cover;
+  background-position: center;
+  background-color: var(--green-700);
+}
+
+.navigation-card__overlay {
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(
+    to bottom,
+    rgba(0, 0, 0, 0.1) 0%,
+    rgba(20, 40, 30, 0.7) 70%,
+    rgba(20, 40, 30, 0.95) 100%
+  );
+}
+
+.navigation-card__content {
+  position: absolute;
+  bottom: 0;
+  left: 0;
+  padding: 14px 10px;
+  z-index: 2;
+}
+
+.navigation-card__title {
+  color: var(--white);
+  font-size: 16px;
+  font-weight: 700;
+  margin: 0;
+  text-shadow: 0 1px 3px rgba(0, 0, 0, 0.3);
+}
+
+.navigation-card__arrow {
+  position: absolute;
+  right: 10px;
+  top: 50%;
+  transform: translateY(-50%);
+  width: 52px;
+  height: 52px;
+  border-radius: 50%;
+  background-color: var(--beige-100);
+  border: none;
+  cursor: pointer;
+  color: var(--gray-900);
+  transition: transform 0.2s ease, background-color 0.2s ease;
+  z-index: 3;
+}
+
+.navigation-card__arrow:hover {
+  background-color: var(--white);
+  transform: translateY(-50%) scale(1.05);
+}
+
+.navigation-card__arrow:active {
+  transform: translateY(-50%) scale(0.98);
+}

--- a/src/app/components/redirectButton 2.js
+++ b/src/app/components/redirectButton 2.js
@@ -1,0 +1,39 @@
+import Icons from "../constants/icons";
+import Image from "next/image";
+import styles from "./redirectButton.module.css";
+import Link from "next/link";
+
+export default function RedirectButton({ link, label, icon, variation = "orange" }) {
+  const selectedIcon = icon ? Icons[icon] : null;
+  const chevronIcon = variation === "white" ? Icons.prosseguir : Icons.prosseguirbranco;
+
+  const button = (
+    <div className={`${styles.button} ${styles[variation]}`}>
+      {selectedIcon && (
+        <div className={styles.icon}>
+          <Image
+            src={selectedIcon.value}
+            alt={selectedIcon.alt}
+            height={21}
+            width={21}
+          />
+        </div>
+      )}
+      <div className={`${styles.content} ${!selectedIcon ? styles.noIcon : ""}`}>{label}</div>
+      <div className={styles.icon}>
+        <Image
+          src={chevronIcon.value}
+          alt={chevronIcon.alt}
+          height={21}
+          width={21}
+        />
+      </div>
+    </div>
+  );
+
+  if (link) {
+    return <Link href={link}>{button}</Link>;
+  }
+
+  return button;
+}

--- a/src/app/components/redirectButton.module 2.css
+++ b/src/app/components/redirectButton.module 2.css
@@ -1,0 +1,48 @@
+.button {
+    display: flex;
+    align-items: center;
+    color: #39542D;
+    border-radius: 10px;
+    margin-top: 1rem;
+    height: 43px;
+}
+
+.orange {
+    background-color: var(--orange-500);
+}
+
+.white {
+    background-color: var(--white);
+}
+
+.icon {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    height: 100%;
+    width: 50px;
+}
+
+.content {
+    text-align: left;
+    font-size: 15px;
+    flex-grow: 1;
+}
+
+.noIcon {
+    padding-left: 21px;
+}
+
+.orange .content {
+    color: #FFFFFF;
+    font-weight: 400;
+}
+
+.white .content {
+    color: #39542D;
+    font-weight: 600;
+}
+
+.button:hover {
+    cursor: pointer;
+}

--- a/src/app/components/searchbar 2.js
+++ b/src/app/components/searchbar 2.js
@@ -1,0 +1,78 @@
+'use client'
+
+import { useEffect, useRef, useState } from "react";
+import styles from "./searchbar.module.css";
+import Label from "@/app/components/label";
+import Image from "next/image";
+import Icons from "@/app/constants/icons";
+
+export default function SearchBar({
+  label,
+  placeholder,
+  height,
+  type = "text",
+  disabled = false,
+  onSearch,
+  debounceMs = 300,
+  initialValue = "",
+}) {
+  const inputRef = useRef(null);
+  const [value, setValue] = useState(initialValue);
+  const debounced = useDebounced(value, debounceMs);
+
+  const lastSent = useRef(null);
+  useEffect(() => {
+    if (!onSearch) return;
+    if (lastSent.current === debounced) return;
+    lastSent.current = debounced;
+    onSearch(debounced);
+  }, [debounced, onSearch]);
+
+  const getStyle = () => {
+    if (disabled) {
+      return styles.disabled;
+    }
+    return styles.input;
+  };
+
+  const controlled = Boolean(onSearch);
+
+  return (
+    <>
+      {label &&
+        <div className={styles.labelpadding}>
+          <Label text={label}/>
+        </div>
+      }
+      <div className='position-relative'>
+        <input
+          ref={inputRef}
+          className={getStyle()}
+          placeholder={placeholder}
+          disabled={disabled}
+          type={type}
+          style={{height}}
+          {...(controlled
+            ? { value, onChange: (e) => setValue(e.target.value) }
+            : {})}
+        />
+        <i className={styles.icon}>
+          <Image
+            src={Icons.pesquisarverde.value}
+            alt={Icons.pesquisarverde.alt}
+            height={20}/>
+        </i>
+        <br />
+      </div>
+    </>
+  );
+}
+
+export function useDebounced(value, ms) {
+  const [debounced, setDebounced] = useState(value);
+  useEffect(() => {
+    const t = setTimeout(() => setDebounced(value), ms);
+    return () => clearTimeout(t);
+  }, [value, ms]);
+  return debounced;
+}

--- a/src/app/components/searchbar.module 2.css
+++ b/src/app/components/searchbar.module 2.css
@@ -1,0 +1,40 @@
+.input {
+    border-radius: 0.5rem;
+    border: 0.1rem solid #757575;
+    padding: 0.5rem 0.8rem;
+    color: #263A1E;
+    background-color: #FFFFFF;
+    width: 100%;
+    height: 2.5rem;
+  }
+  
+  .input:focus {
+    outline-color: #84C868;
+  }
+  
+  .disabled {
+    border-radius: 0.5rem;
+    background-color: #7575751A;
+    color: #7575751A;
+    border: 0;
+    padding: 0.5rem;
+    width: 100%;
+    position: rel;
+  }
+  
+  .icon {
+    margin-top: 10px;
+    position: absolute;
+    right: 12px;
+  }
+  
+  .labelpadding {
+    margin-bottom: 0.25rem !important;
+  }
+
+  .input::placeholder {
+    color: #39542D;
+    font-family: 'Montserrat';
+    font-weight: bold;
+  }
+  

--- a/src/app/components/skeleton 2.js
+++ b/src/app/components/skeleton 2.js
@@ -1,0 +1,25 @@
+import styles from "./skeleton.module.css";
+
+export default function Skeleton({
+  width = "100%",
+  height = 16,
+  radius,
+  className = "",
+  style,
+  ariaLabel = "Carregando",
+}) {
+  return (
+    <div
+      role="status"
+      aria-live="polite"
+      aria-label={ariaLabel}
+      className={`${styles.skeleton} ${className}`.trim()}
+      style={{
+        width,
+        height,
+        ...(radius !== undefined ? { borderRadius: radius } : null),
+        ...style,
+      }}
+    />
+  );
+}

--- a/src/app/components/skeleton.module 2.css
+++ b/src/app/components/skeleton.module 2.css
@@ -1,0 +1,40 @@
+.skeleton {
+  position: relative;
+  display: block;
+  overflow: hidden;
+  background-color: #d6d3c4;
+  border-radius: 8px;
+  min-height: 12px;
+}
+
+.skeleton::after {
+  content: "";
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background: linear-gradient(
+    90deg,
+    rgba(255, 255, 255, 0) 0%,
+    rgba(255, 255, 255, 0.7) 50%,
+    rgba(255, 255, 255, 0) 100%
+  );
+  transform: translateX(-100%);
+  animation: shimmer 1.4s ease-in-out infinite;
+}
+
+@keyframes shimmer {
+  0% {
+    transform: translateX(-100%);
+  }
+  100% {
+    transform: translateX(100%);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .skeleton::after {
+    animation: none;
+  }
+}

--- a/src/app/providers 2.js
+++ b/src/app/providers 2.js
@@ -1,0 +1,37 @@
+"use client";
+
+import { Auth0Provider } from "@auth0/auth0-react";
+import { useRouter } from "next/navigation";
+import { getConfig } from "./config";
+
+export function Providers({ children }) {
+  const config = getConfig();
+  const router = useRouter();
+
+  // Auth0 redirects back to this URL after login. Pin it to the app origin so
+  // the tenant's allow-list can be a single fixed entry; the actual destination
+  // ride-shares through `appState.returnTo` and is restored below.
+  const redirectUri =
+    typeof window !== "undefined" ? window.location.origin : "";
+
+  const onRedirectCallback = (appState) => {
+    router.replace(appState?.returnTo || window.location.pathname);
+  };
+
+  // `audience` is only forwarded when configured (see getConfig). When present
+  // the SDK issues an access token for the backend API instead of just an ID
+  // token — admin write calls depend on this.
+  return (
+    <Auth0Provider
+      domain={config.domain}
+      clientId={config.clientId}
+      authorizationParams={{
+        redirect_uri: redirectUri,
+        ...(config.audience ? { audience: config.audience } : null),
+      }}
+      onRedirectCallback={onRedirectCallback}
+    >
+      {children}
+    </Auth0Provider>
+  );
+}

--- a/src/app/validators/dateValidator 2.js
+++ b/src/app/validators/dateValidator 2.js
@@ -1,0 +1,16 @@
+// Native <input type="date"> gives us YYYY-MM-DD already, so we only check
+// shape — cheap and predictable.
+const DATE_RE = /^\d{4}-\d{2}-\d{2}$/;
+
+export default class DateValidator {
+  static make() {
+    return (value) => {
+      if (typeof value !== "string") return false;
+      const trimmed = value.trim();
+      if (trimmed === "") return false;
+      if (!DATE_RE.test(trimmed)) return false;
+      const d = new Date(`${trimmed}T00:00:00Z`);
+      return !Number.isNaN(d.getTime());
+    };
+  }
+}

--- a/src/app/validators/numberValidator 2.js
+++ b/src/app/validators/numberValidator 2.js
@@ -1,0 +1,14 @@
+// Accepts integers, decimals (dot or comma), positive and negative. Empty is
+// treated as invalid — the Input component short-circuits empty+optional
+// before calling this so this only runs when the user actually typed something.
+export default class NumberValidator {
+  static make() {
+    return (value) => {
+      if (typeof value !== "string") return typeof value === "number";
+      const normalised = value.trim().replace(",", ".");
+      if (normalised === "") return false;
+      const n = Number(normalised);
+      return Number.isFinite(n);
+    };
+  }
+}

--- a/src/app/validators/urlValidator 2.js
+++ b/src/app/validators/urlValidator 2.js
@@ -1,0 +1,18 @@
+// Simple URL validator — matches http(s):// followed by a host and optional path.
+// Kept lenient so admins can paste real-world image/social URLs without
+// tripping over trailing punctuation or Unicode.
+export default class UrlValidator {
+  static make() {
+    return (value) => {
+      if (typeof value !== "string") return false;
+      const trimmed = value.trim();
+      if (trimmed.length === 0) return false;
+      try {
+        const u = new URL(trimmed);
+        return u.protocol === "http:" || u.protocol === "https:";
+      } catch {
+        return false;
+      }
+    };
+  }
+}

--- a/src/lib/apiAuth 2.js
+++ b/src/lib/apiAuth 2.js
@@ -1,0 +1,47 @@
+/**
+ * Bearer-token bridge between the Auth0 client (React context) and the
+ * plain-JS API client (`src/lib/api.js`).
+ *
+ * Auth0's `getAccessTokenSilently` is only reachable via the `useAuth0` hook
+ * from a React component. `api.js` is not a component and would otherwise
+ * duplicate token retrieval per resource. Instead, the admin layout registers
+ * a token provider on mount; every subsequent write request pulls its token
+ * from here. Public GETs remain token-free.
+ *
+ * The provider is unset by default so public pages don't accidentally attach
+ * a token. In non-admin contexts, `getAccessToken()` resolves to `null` and
+ * requests go out anonymously.
+ */
+
+let tokenProvider = async () => null;
+
+/**
+ * Register a function that returns a Promise<string | null> resolving to an
+ * Auth0 access token. Call this once, in an effect, from the admin layout.
+ *
+ * @param {() => Promise<string | null>} fn
+ */
+export const setTokenProvider = (fn) => {
+  tokenProvider = typeof fn === "function" ? fn : async () => null;
+};
+
+/** Clear the provider — used on logout or unmount to prevent stale tokens. */
+export const clearTokenProvider = () => {
+  tokenProvider = async () => null;
+};
+
+/**
+ * Awaited by the API client on every write. Errors from the provider (e.g.
+ * silent auth failure) are swallowed here — the API layer will treat them as
+ * "no token" and receive a 401 from the server, which the UI surfaces via
+ * ApiError.
+ *
+ * @returns {Promise<string | null>}
+ */
+export const getAccessToken = async () => {
+  try {
+    return await tokenProvider();
+  } catch {
+    return null;
+  }
+};

--- a/src/lib/supabaseStorage 2.js
+++ b/src/lib/supabaseStorage 2.js
@@ -1,0 +1,62 @@
+/**
+ * Supabase Storage helper for admin image uploads.
+ *
+ * The backend accepts image URLs as strings; there is no upload endpoint.
+ * `sql/0001_initial_schema.sql` documents the intended pattern: SPA uploads
+ * to a public Supabase Storage bucket, then submits the resulting public URL.
+ *
+ * This module lazily creates a Supabase client only when Storage is used —
+ * we don't need it for auth (that's Auth0). If the env vars aren't set,
+ * `uploadPublicImage` throws a helpful error instead of failing on load.
+ */
+
+let cachedClient = null;
+
+const getClient = async () => {
+  if (cachedClient) return cachedClient;
+  const url = process.env.NEXT_PUBLIC_SUPABASE_URL;
+  const key = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY;
+  if (!url || !key) {
+    throw new Error(
+      "Supabase Storage não configurado. Defina NEXT_PUBLIC_SUPABASE_URL e NEXT_PUBLIC_SUPABASE_ANON_KEY em .env.local."
+    );
+  }
+  // Dynamic import so the admin-only dependency isn't bundled into the
+  // public-site JS payload — webpack will still resolve it at build time and
+  // split it into its own chunk.
+  const { createClient } = await import("@supabase/supabase-js");
+  cachedClient = createClient(url, key, { auth: { persistSession: false } });
+  return cachedClient;
+};
+
+/**
+ * Upload a File to the public `images` bucket. Returns the public URL.
+ *
+ * Folder pattern: `<prefix>/<timestamp>-<random>-<sanitised-name>`. Prefix
+ * lets us organise by resource (brigades/, articles/, news/) so a Storage
+ * admin can prune orphaned files.
+ *
+ * @param {File} file
+ * @param {{ prefix?: string, bucket?: string }} [opts]
+ * @returns {Promise<string>} public URL
+ */
+export const uploadPublicImage = async (file, { prefix = "misc", bucket = "images" } = {}) => {
+  if (!file) throw new Error("Nenhum arquivo selecionado.");
+  const client = await getClient();
+
+  const safeName = file.name.replace(/[^a-zA-Z0-9._-]+/g, "-").toLowerCase();
+  const stamp = Date.now().toString(36);
+  const rand = Math.random().toString(36).slice(2, 8);
+  const path = `${prefix}/${stamp}-${rand}-${safeName}`;
+
+  const { error } = await client.storage.from(bucket).upload(path, file, {
+    cacheControl: "3600",
+    upsert: false,
+    contentType: file.type || undefined,
+  });
+  if (error) throw new Error(error.message || "Falha no upload da imagem.");
+
+  const { data } = client.storage.from(bucket).getPublicUrl(path);
+  if (!data?.publicUrl) throw new Error("Upload concluído mas URL pública não disponível.");
+  return data.publicUrl;
+};


### PR DESCRIPTION
## Resumo
Substitui o `Select` padrão da página de Contato por um `CustomSelect` fiel ao mock (chevron que inverte, checkmark verde na opção selecionada, painel arredondado com sombra) e integra a lista de brigadas com o banco.

## Mudanças
- **Novo componente** `CustomSelect` (`contactPage/components/customSelect.js` + `.module.css`): dropdown customizado, com busca opcional (`searchable`), estado de `loading` e `<input type="hidden">` para manter compatibilidade com o form atual (que lê valores via `document.getElementsByName`).
- **page.js**: troca todos os `Select` por `CustomSelect`; carrega brigadas reais via `api.brigades.list` com a **RNBV fixa no topo** como default; adiciona validação do campo brigada; limpa o erro de cada campo assim que o usuário começa a corrigi-lo; reseta a cidade ao trocar de estado.
- **css.css**: estilos de apoio para o novo layout do formulário.

## Notas
- Fallback: se o fetch de brigadas falhar, ao menos a RNBV permanece disponível.

🤖 Generated with [Claude Code](https://claude.com/claude-code)