### PR TITLE
feat: publication detail page with brigades, PIX repeat and news caro…

### DIFF
--- a/src/app/(public)/publicacao/[slug]/components/latestNewsCarousel.js
+++ b/src/app/(public)/publicacao/[slug]/components/latestNewsCarousel.js
@@ -1,0 +1,141 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import Link from "next/link";
+import { api } from "@/lib/api";
+import styles from "./latestNewsCarousel.module.css";
+
+/**
+ * Carrossel "Últimas notícias" exibido ao final da página de detalhe.
+ *
+ * Mostra UMA notícia por vez (imagem + título + resumo) com setas de navegação
+ * que dão a volta (wrap-around) e um botão "Saiba Mais" que abre o detalhe da
+ * notícia atual. Se não houver notícias, o componente não renderiza nada.
+ *
+ * `excludeId` evita listar a própria notícia quando o detalhe aberto já é uma
+ * notícia.
+ */
+
+const NEWS_LIMIT = 8;
+
+const byMostRecent = (a, b) =>
+  (Date.parse(b.publishedAt || b.createdAt) || 0) -
+  (Date.parse(a.publishedAt || a.createdAt) || 0);
+
+export default function LatestNewsCarousel({ excludeId = null }) {
+  const [news, setNews] = useState([]);
+  const [index, setIndex] = useState(0);
+
+  useEffect(() => {
+    const ctrl = new AbortController();
+    const load = async () => {
+      try {
+        const res = await api.news.list({ limit: NEWS_LIMIT }, { signal: ctrl.signal });
+        const items = (res?.data ?? [])
+          .filter((n) => n.id !== excludeId)
+          .sort(byMostRecent);
+        setNews(items);
+        setIndex(0);
+      } catch (err) {
+        if (err.name === "AbortError") return;
+        // eslint-disable-next-line no-console
+        console.error("[LatestNewsCarousel] load failed", err);
+      }
+    };
+    load();
+    return () => ctrl.abort();
+  }, [excludeId]);
+
+  if (!news.length) return null;
+
+  const current = news[index];
+  const multiple = news.length > 1;
+  const prev = () => setIndex((i) => (i - 1 + news.length) % news.length);
+  const next = () => setIndex((i) => (i + 1) % news.length);
+
+  return (
+    <section
+      className={styles.section}
+      aria-roledescription="carrossel"
+      aria-label="Últimas notícias"
+    >
+      <h2 className={styles.heading}>Últimas notícias</h2>
+
+      <div className={styles.carousel}>
+        {multiple && (
+          <button
+            type="button"
+            className={styles.navButton}
+            onClick={prev}
+            aria-label="Notícia anterior"
+          >
+            <svg width="28" height="28" viewBox="0 0 24 24" fill="none">
+              <path
+                d="M15 18L9 12L15 6"
+                stroke="currentColor"
+                strokeWidth="2"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+              />
+            </svg>
+          </button>
+        )}
+
+        <div className={styles.viewport}>
+          <Link
+            href={`/publicacao/news-${current.id}`}
+            className={styles.cardLink}
+            aria-label={`Abrir notícia: ${current.title}`}
+          >
+            <article className={styles.card}>
+              {current.imageUrl && (
+                // eslint-disable-next-line @next/next/no-img-element
+                <img
+                  className={styles.image}
+                  src={current.imageUrl}
+                  alt={current.title}
+                />
+              )}
+              <h3 className={styles.cardTitle}>{current.title}</h3>
+              <p className={styles.cardSummary}>
+                {current.summary || current.subtitle || ""}
+              </p>
+            </article>
+          </Link>
+        </div>
+
+        {multiple && (
+          <button
+            type="button"
+            className={styles.navButton}
+            onClick={next}
+            aria-label="Próxima notícia"
+          >
+            <svg width="28" height="28" viewBox="0 0 24 24" fill="none">
+              <path
+                d="M9 18L15 12L9 6"
+                stroke="currentColor"
+                strokeWidth="2"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+              />
+            </svg>
+          </button>
+        )}
+      </div>
+
+      <Link href="/viewCampaignsPage?tipo=noticias" className={styles.saibaMais}>
+        <svg width="22" height="22" viewBox="0 0 24 24" fill="none" aria-hidden="true">
+          <circle cx="12" cy="12" r="9" stroke="currentColor" strokeWidth="2" />
+          <path
+            d="M12 8v8M8 12h8"
+            stroke="currentColor"
+            strokeWidth="2"
+            strokeLinecap="round"
+          />
+        </svg>
+        Saiba Mais
+      </Link>
+    </section>
+  );
+}

--- a/src/app/(public)/publicacao/[slug]/components/latestNewsCarousel.module.css
+++ b/src/app/(public)/publicacao/[slug]/components/latestNewsCarousel.module.css
@@ -1,0 +1,95 @@
+.section {
+  margin-top: 2.5rem;
+}
+
+.heading {
+  color: #39542d;
+  font-size: 1.5rem;
+  font-weight: 700;
+  margin: 0 0 1rem;
+}
+
+.carousel {
+  display: flex;
+  align-items: center;
+  gap: 0.25rem;
+}
+
+.navButton {
+  background: none;
+  border: none;
+  color: #39542d;
+  cursor: pointer;
+  padding: 0.25rem;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+  transition: opacity 0.2s;
+}
+
+.navButton:hover {
+  opacity: 0.6;
+}
+
+.viewport {
+  flex: 1;
+  min-width: 0;
+}
+
+.cardLink {
+  display: block;
+  text-decoration: none;
+  color: inherit;
+}
+
+.card {
+  display: flex;
+  flex-direction: column;
+}
+
+.image {
+  width: 100%;
+  height: auto;
+  aspect-ratio: 16 / 10;
+  object-fit: cover;
+  border-radius: 12px;
+  display: block;
+}
+
+.cardTitle {
+  color: #1a1a1a;
+  font-size: 1.05rem;
+  font-weight: 600;
+  line-height: 1.3;
+  margin: 0.75rem 0 0.35rem;
+}
+
+.cardSummary {
+  color: #333;
+  font-size: 0.95rem;
+  line-height: 1.45;
+  margin: 0;
+}
+
+.saibaMais {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.6rem;
+  width: 100%;
+  margin-top: 1.5rem;
+  padding: 0.9rem 1rem;
+  border: 1px solid #39542d;
+  border-radius: 12px;
+  color: #39542d;
+  font-size: 1.05rem;
+  text-decoration: none;
+  background: none;
+  cursor: pointer;
+  transition: background 0.15s ease;
+}
+
+.saibaMais:hover {
+  background: #f0f3ee;
+}

--- a/src/app/(public)/publicacao/[slug]/page.js
+++ b/src/app/(public)/publicacao/[slug]/page.js
@@ -1,0 +1,209 @@
+'use client'
+
+import { useEffect, useState } from "react";
+import { useParams } from "next/navigation";
+import { api } from "@/lib/api";
+import LatestNewsCarousel from "./components/latestNewsCarousel";
+import styles from "./page.module.css";
+
+/**
+ * Página de detalhe de uma publicação (campanha, notícia ou artigo).
+ *
+ * A lista em `viewCampaignsPage` unifica os três tipos e gera ids compostos no
+ * formato `campaign-<id>` / `news-<id>` / `article-<id>`. Aqui o slug é
+ * quebrado no PRIMEIRO hífen apenas, porque o id em si é um UUID e também
+ * contém hífens.
+ *
+ * A tela mostra o título e, em seguida, o corpo completo. O `body` é HTML
+ * produzido pelo editor rich-text do admin (react-quill), então é renderizado
+ * via dangerouslySetInnerHTML. Quando não há `body` (ex.: campanha que só tem
+ * `description` em texto puro), caímos no texto simples preservando quebras.
+ *
+ * Abaixo do texto, quando houver dados configurados no banco (para qualquer
+ * tipo de publicação), exibimos: imagem de capa, botão de doação (copia a chave
+ * PIX), os Resultados (GET /api/campaigns/:id/results), as Brigadas
+ * Participantes (GET /api/{tipo}/:id/brigades) e novamente o botão de doação.
+ * Seções sem dados simplesmente não são renderizadas.
+ */
+
+const RESOURCE_BY_PREFIX = {
+  campaign: "campaigns",
+  news: "news",
+  article: "articles",
+};
+
+const parseSlug = (slug) => {
+  const sep = slug.indexOf("-");
+  if (sep === -1) return { resource: null, id: null };
+  const prefix = slug.slice(0, sep);
+  const id = slug.slice(sep + 1);
+  return { resource: RESOURCE_BY_PREFIX[prefix] ?? null, id };
+};
+
+const copyToClipboard = async (text) => {
+  if (navigator.clipboard?.writeText) {
+    await navigator.clipboard.writeText(text);
+    return;
+  }
+  // Fallback para contextos sem a Clipboard API.
+  const ta = document.createElement("textarea");
+  ta.value = text;
+  ta.style.position = "fixed";
+  ta.style.opacity = "0";
+  document.body.appendChild(ta);
+  ta.select();
+  document.execCommand("copy");
+  document.body.removeChild(ta);
+};
+
+/**
+ * Botão de doação PIX. Estado de feedback local para poder ser usado em mais
+ * de um ponto da página sem que os botões compartilhem o "copiado".
+ */
+function DonateBlock({ pix }) {
+  const [copied, setCopied] = useState(false);
+  const handleCopy = async () => {
+    try {
+      await copyToClipboard(pix);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 3000);
+    } catch {
+      setCopied(false);
+    }
+  };
+  return (
+    <>
+      <button type="button" className={styles.donateButton} onClick={handleCopy}>
+        Faça uma doação
+      </button>
+      <p className={styles.donateFeedback} role="status" aria-live="polite">
+        {copied ? "Chave PIX copiada!" : "Toque para copiar a chave PIX"}
+      </p>
+    </>
+  );
+}
+
+export default function PublicationDetailPage() {
+  const { slug } = useParams();
+  const { resource, id } = parseSlug(String(slug ?? ""));
+  const isCampaign = resource === "campaigns";
+
+  const [item, setItem] = useState(null);
+  const [results, setResults] = useState([]);
+  const [brigades, setBrigades] = useState([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(null);
+
+  useEffect(() => {
+    const ctrl = new AbortController();
+    const load = async () => {
+      if (!resource) {
+        setError("Publicação não encontrada.");
+        setLoading(false);
+        return;
+      }
+      try {
+        setLoading(true);
+        setError(null);
+        const [res, resultsRes, brigadesRes] = await Promise.all([
+          api[resource].get(id, { signal: ctrl.signal }),
+          isCampaign
+            ? api.campaigns.results(id, { signal: ctrl.signal })
+            : Promise.resolve(null),
+          api[resource].brigades(id, { signal: ctrl.signal }),
+        ]);
+        setItem(res?.data ?? res);
+        setResults(resultsRes?.data ?? []);
+        setBrigades(brigadesRes?.data ?? []);
+      } catch (err) {
+        if (err.name === "AbortError") return;
+        // eslint-disable-next-line no-console
+        console.error("[PublicationDetail] load failed", err);
+        setError("Não foi possível carregar a publicação.");
+      } finally {
+        setLoading(false);
+      }
+    };
+    load();
+    return () => ctrl.abort();
+  }, [slug]);
+
+  if (loading) return <p className={styles.state}>Carregando...</p>;
+  if (error) return <p className={styles.error}>{error}</p>;
+  if (!item) return null;
+
+  const html = item.body?.trim() ? item.body : null;
+  const fallback = item.description || item.summary || item.subtitle || "";
+
+  return (
+    <article className={styles.wrapper}>
+      <h1 className={styles.title}>{item.title}</h1>
+
+      {html ? (
+        <div
+          className={styles.body}
+          dangerouslySetInnerHTML={{ __html: html }}
+        />
+      ) : (
+        <div className={styles.body} style={{ whiteSpace: "pre-wrap" }}>
+          {fallback}
+        </div>
+      )}
+
+      {item.imageUrl && (
+        // eslint-disable-next-line @next/next/no-img-element
+        <img
+          className={styles.coverImage}
+          src={item.imageUrl}
+          alt={item.title}
+        />
+      )}
+
+      {item.pix && <DonateBlock pix={item.pix} />}
+
+      {results.length > 0 && (
+        <>
+          <h2 className={styles.resultsHeading}>Resultados</h2>
+          <div className={styles.resultsBox}>
+            {results.map((r) => (
+              <div key={r.id} className={styles.resultItem}>
+                <span className={styles.resultValue}>{r.value}</span>
+                <span className={styles.resultLabel}>{r.label}</span>
+              </div>
+            ))}
+          </div>
+        </>
+      )}
+
+      {brigades.length > 0 && (
+        <section className={styles.brigadesSection}>
+          <h2 className={styles.brigadesHeading}>Brigadas Participantes</h2>
+          <p className={styles.brigadesIntro}>
+            Agradecemos o reconhecimento e o esforço dos artistas e toda a
+            equipe de apoio em divulgar a dedicação dos Brigadistas Voluntários
+            do Brasil.
+          </p>
+          <div className={styles.brigadesGrid}>
+            {brigades.map((b) => (
+              <div key={b.id} className={styles.brigadeItem}>
+                {b.imageUrl && (
+                  // eslint-disable-next-line @next/next/no-img-element
+                  <img
+                    className={styles.brigadeLogo}
+                    src={b.imageUrl}
+                    alt={b.name}
+                  />
+                )}
+                <span className={styles.brigadeName}>{b.name}</span>
+              </div>
+            ))}
+          </div>
+        </section>
+      )}
+
+      {brigades.length > 0 && item.pix && <DonateBlock pix={item.pix} />}
+
+      <LatestNewsCarousel excludeId={resource === "news" ? id : null} />
+    </article>
+  );
+}

--- a/src/app/(public)/publicacao/[slug]/page.module.css
+++ b/src/app/(public)/publicacao/[slug]/page.module.css
@@ -1,0 +1,173 @@
+.wrapper {
+  max-width: 820px;
+  margin: 0 auto;
+  padding: 2rem 1.5rem 4rem;
+}
+
+.title {
+  color: #39542d;
+  font-size: 1.7rem;
+  font-weight: 700;
+  line-height: 1.25;
+  margin: 0 0 1.5rem;
+}
+
+.body {
+  color: #1a1a1a;
+  font-size: 1.05rem;
+  line-height: 1.6;
+}
+
+/* Espaçamento dos parágrafos vindos do HTML do editor (react-quill). */
+.body p {
+  margin: 0 0 1rem;
+}
+
+.body a {
+  color: #1e88e5;
+  text-decoration: underline;
+}
+
+.body ul,
+.body ol {
+  margin: 0 0 1rem 1.25rem;
+}
+
+/* ---- Bloco específico de campanha ---- */
+
+.coverImage {
+  display: block;
+  width: 100%;
+  height: auto;
+  object-fit: cover;
+  border-radius: 12px;
+  margin: 2rem 0 1.25rem;
+}
+
+.donateButton {
+  display: block;
+  width: 100%;
+  background: #c67b3f;
+  color: #fff;
+  border: none;
+  border-radius: 10px;
+  padding: 1rem 1.25rem;
+  font-size: 1.1rem;
+  font-weight: 500;
+  cursor: pointer;
+  transition: background 0.15s ease;
+}
+
+.donateButton:hover {
+  background: #b56d33;
+}
+
+.donateFeedback {
+  color: #39542d;
+  font-size: 0.95rem;
+  text-align: center;
+  margin: 0.6rem 0 0;
+}
+
+.resultsHeading {
+  color: #39542d;
+  font-size: 1.5rem;
+  font-weight: 700;
+  margin: 2.5rem 0 1rem;
+}
+
+.resultsBox {
+  display: flex;
+  background: #f2f2f0;
+  border-radius: 12px;
+  padding: 1.5rem 1rem;
+}
+
+.resultItem {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  text-align: center;
+  padding: 0 0.5rem;
+}
+
+.resultItem:not(:last-child) {
+  border-right: 1px solid #d5d5d0;
+}
+
+.resultValue {
+  color: #39542d;
+  font-size: 1.6rem;
+  font-weight: 700;
+  line-height: 1.1;
+}
+
+.resultLabel {
+  color: #5a6b4f;
+  font-size: 0.85rem;
+  margin-top: 0.35rem;
+}
+
+.state {
+  color: #757575;
+  padding: 2rem 1.5rem;
+}
+
+.error {
+  color: #c62828;
+  padding: 2rem 1.5rem;
+}
+
+/* ---- Brigadas participantes ---- */
+
+.brigadesSection {
+  margin-top: 2.5rem;
+}
+
+.brigadesHeading {
+  color: #39542d;
+  font-size: 1.5rem;
+  font-weight: 700;
+  margin: 0 0 0.75rem;
+}
+
+.brigadesIntro {
+  color: #1a1a1a;
+  font-size: 1.05rem;
+  line-height: 1.5;
+  margin: 0 0 1.75rem;
+}
+
+.brigadesGrid {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: 1.75rem 1rem;
+}
+
+.brigadeItem {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  text-align: center;
+  gap: 0.6rem;
+}
+
+.brigadeLogo {
+  width: 72px;
+  height: 72px;
+  object-fit: contain;
+  border-radius: 50%;
+}
+
+.brigadeName {
+  color: #39542d;
+  font-size: 0.95rem;
+  line-height: 1.2;
+}
+
+@media (max-width: 520px) {
+  .brigadesGrid {
+    grid-template-columns: repeat(3, 1fr);
+  }
+}

--- a/src/app/(public)/viewCampaignsPage/components/articleCard.js
+++ b/src/app/(public)/viewCampaignsPage/components/articleCard.js
@@ -1,35 +1,42 @@
 'use client'
 
 import Image from "next/image";
+import Link from "next/link";
 import styles from "./articleCard.module.css";
 
 export default function ArticleCard({ article }) {
   return (
-    <article className={styles.card}>
-      <div className={styles.imageContainer}>
-        <Image
-          src={article.image}
-          alt={article.title}
-          width={350}
-          height={180}
-          className={styles.cardImage}
-        />
-        <span
-          className={styles.categoryBadge}
-          style={{ backgroundColor: article.categoryColor }}
-        >
-          {article.category}
-        </span>
-        <button className={styles.arrowButton} aria-label="Ver artigo completo">
-          <svg width="24" height="24" viewBox="0 0 24 24" fill="none">
-            <path d="M9 18l6-6-6-6" stroke="#39542D" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"/>
-          </svg>
-        </button>
-      </div>
-      <div className={styles.contentContainer}>
-        <h2 className={styles.title}>{article.title}</h2>
-      </div>
-      <p className={styles.description}>{article.description}</p>
-    </article>
+    <Link
+      href={`/publicacao/${article.id}`}
+      aria-label={`Abrir: ${article.title}`}
+      style={{ textDecoration: "none", color: "inherit", display: "block" }}
+    >
+      <article className={styles.card}>
+        <div className={styles.imageContainer}>
+          <Image
+            src={article.image}
+            alt={article.title}
+            width={350}
+            height={180}
+            className={styles.cardImage}
+          />
+          <span
+            className={styles.categoryBadge}
+            style={{ backgroundColor: article.categoryColor }}
+          >
+            {article.category}
+          </span>
+          <span className={styles.arrowButton} aria-hidden="true">
+            <svg width="24" height="24" viewBox="0 0 24 24" fill="none">
+              <path d="M9 18l6-6-6-6" stroke="#39542D" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"/>
+            </svg>
+          </span>
+        </div>
+        <div className={styles.contentContainer}>
+          <h2 className={styles.title}>{article.title}</h2>
+        </div>
+        <p className={styles.description}>{article.description}</p>
+      </article>
+    </Link>
   );
 }

--- a/src/lib/api.js
+++ b/src/lib/api.js
@@ -135,9 +135,16 @@ export const api = {
   campaigns: {
     ...crudResource("/api/campaigns"),
     results: (id, opts) => apiGet(`/api/campaigns/${enc(id)}/results`, opts),
+    brigades: (id, opts) => apiGet(`/api/campaigns/${enc(id)}/brigades`, opts),
   },
-  news: crudResource("/api/news"),
-  articles: crudResource("/api/articles"),
+  news: {
+    ...crudResource("/api/news"),
+    brigades: (id, opts) => apiGet(`/api/news/${enc(id)}/brigades`, opts),
+  },
+  articles: {
+    ...crudResource("/api/articles"),
+    brigades: (id, opts) => apiGet(`/api/articles/${enc(id)}/brigades`, opts),
+  },
   faqs: {
     // Backend has no GET /:id — admin edit form loads a single FAQ from list().
     list: (params, opts) => apiGet("/api/faqs", { params, ...opts }),


### PR DESCRIPTION
…usel

- publicacao/[slug]/page.js: reusable DonateBlock (PIX copy), fetches item + results (campaigns) + participating brigades in parallel; renders Brigadas Participantes section (when present) with the PIX donate button repeated below it
- latestNewsCarousel: 'Ultimas noticias' carousel; clicking a card opens that news (/publicacao/news-<id>), 'Saiba Mais' goes to the listing
- api.js: add .brigades() to campaigns/news/articles resources
- articleCard.js: wrap card in Link to the detail page